### PR TITLE
Fixed typo in path for verse_num parameter

### DIFF
--- a/routers/chapter_route.py
+++ b/routers/chapter_route.py
@@ -44,7 +44,7 @@ async def get_all_verses_by_chapter(chapter_num: int, db: Session = Depends(get_
 
 
 @router.get(
-    '/{chapter_num}/verses/{verse_number}',
+    '/{chapter_num}/verses/{verse_num}',
     status_code=status.HTTP_200_OK,
     response_model=VerseModel,
     tags=['verses']


### PR DESCRIPTION
Issue fixing #7 occurred due to a typo in naming `verse_number` in the below-mentioned line:

https://github.com/chauhannaman98/ramcharitmanas-api/blob/975f051d5229282c5cacc8125dadeec98741a228/routers/chapter_route.py#L47

